### PR TITLE
Support for subdirectories in a language

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -38,12 +38,28 @@ export const parseAll = (folderPath: string): { name: string; path: string }[] =
     const lang = {}
 
     fs.readdirSync(folderPath + path.sep + folder)
-      .filter((file) => !fs.statSync(folderPath + path.sep + folder + path.sep + file).isDirectory())
       .sort()
-      .forEach((file) => {
-        lang[file.replace(/\.\w+$/, '')] = parse(
-          fs.readFileSync(folderPath + path.sep + folder + path.sep + file).toString()
-        )
+      .forEach((langFolderItem) => {
+        const langFolderPath = folderPath + path.sep + folder
+        const langFolderItemPath = langFolderPath + path.sep + langFolderItem
+
+        if (fs.statSync(langFolderItemPath).isDirectory()) {
+          // Lang sub folder
+          const subFolderFileKey = langFolderItem.replace(/\.\w+$/, '')
+          lang[subFolderFileKey] = {}
+
+          fs.readdirSync(langFolderItemPath)
+            .filter((file) => !fs.statSync(langFolderItemPath + path.sep + file).isDirectory())
+            .sort()
+            .forEach((file) => {
+              lang[subFolderFileKey][file.replace(/\.\w+$/, '')] = parse(
+                fs.readFileSync(langFolderItemPath + path.sep + file).toString()
+              )
+            })
+        } else {
+          // Lang file
+          lang[langFolderItem.replace(/\.\w+$/, '')] = parse(fs.readFileSync(langFolderItemPath).toString())
+        }
       })
 
     data.push({

--- a/test/fixtures/lang/en/domain/car.php
+++ b/test/fixtures/lang/en/domain/car.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'car' => 'Car|Cars',
+    'is_electric' => 'Electric',
+    'charge_speed' => 'Charge speed',
+    'foo' => [
+        'level1' => [
+            'level2' => 'barpt'
+        ]
+    ],
+];

--- a/test/fixtures/lang/en/domain/user.php
+++ b/test/fixtures/lang/en/domain/user.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'user' => 'User|Users',
+    'first_name' => 'First name',
+    'sub_dir_support_is_amazing' => 'Subdirectory support is amazing',
+];

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -21,6 +21,15 @@ it('creates a file for each lang', () => {
     expect(langPt['auth.foo.level1.level2']).toBe('barpt');
 });
 
+it('includes .php lang file in subdirectory in .json', () => {
+    const files = parseAll(__dirname + '/fixtures/lang/');
+    const langEn = JSON.parse(fs.readFileSync(files[0].path).toString());
+
+    expect(langEn['domain.user.sub_dir_support_is_amazing']).toBe('Subdirectory support is amazing');
+    expect(langEn['domain.car.is_electric']).toBe('Electric');
+    expect(langEn['domain.car.foo.level1.level2']).toBe('barpt');
+});
+
 it('transforms .php lang to .json', () => {
     const lang = parse(fs.readFileSync(__dirname + '/fixtures/lang/en/auth.php').toString());
 


### PR DESCRIPTION
This PR adds support for subdirectories in a language folder like:` lang/en/domain/car.php`.
Solves #43 .

- [x] Fixtures added

- [x] Tests added

- [x] Tested in Laravel application