### PR TITLE
fix: Nested translations aren't translated

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -337,6 +337,8 @@ export class I18n {
    * Get the translation for the given key and watch for any changes.
    */
   wTrans(key: string, replacements: ReplacementsInterface = {}): ComputedRef<string> {
+    key = key.replace(/\//g, '.')
+
     if (!this.activeMessages[key]) {
       const hasChildItems = this.activeMessages[`${key}.0`] !== undefined
 

--- a/test/fixtures/lang/en/nested/cars/car.php
+++ b/test/fixtures/lang/en/nested/cars/car.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'is_electric' => 'Electric',
+    'foo' => [
+        'level1' => [
+            'level2' => 'barpt',
+        ]
+    ]
+];

--- a/test/fixtures/lang/pt/nested/cars/car.php
+++ b/test/fixtures/lang/pt/nested/cars/car.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'is_electric' => 'É elétrico?',
+    'foo' => [
+        'level1' => [
+            'level2' => 'barpt',
+        ]
+    ]
+];

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -30,6 +30,14 @@ it('includes .php lang file in subdirectory in .json', () => {
     expect(langEn['domain.car.foo.level1.level2']).toBe('barpt');
 });
 
+it('includes .php lang file in nested subdirectory in .json', () => {
+    const files = parseAll(__dirname + '/fixtures/lang/');
+    const langEn = JSON.parse(fs.readFileSync(files[0].path).toString())
+
+    expect(langEn['nested.cars.car.is_electric']).toBe('Electric');
+    expect(langEn['nested.cars.car.foo.level1.level2']).toBe('barpt');
+})
+
 it('transforms .php lang to .json', () => {
     const lang = parse(fs.readFileSync(__dirname + '/fixtures/lang/en/auth.php').toString());
 

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -191,3 +191,10 @@ it('translates a possible nested item, and if not exists check on the root level
   await global.mountPlugin(undefined, 'pt');
   expect(trans('foo.bar')).toBe('baz');
 });
+
+it('translates a nested file item while using "/" and "." at the same time as a delimiter', async () => {
+  await global.mountPlugin()
+
+  expect(trans('nested/cars/car.is_electric')).toBe('É elétrico?');
+  expect(trans('nested/cars/car.foo.level1.level2')).toBe('barpt');
+})


### PR DESCRIPTION
Fixes #84

Also adds `/` as a possible trans delimiter. The reason is type hinting in PHPStorm because that's the default way Laravel has made nested translations.