### PR TITLE
fix: Translation of strings that use delimiter symbols

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -337,7 +337,9 @@ export class I18n {
    * Get the translation for the given key and watch for any changes.
    */
   wTrans(key: string, replacements: ReplacementsInterface = {}): ComputedRef<string> {
-    key = key.replace(/\//g, '.')
+    if (!this.activeMessages[key] && !this.activeMessages[`${key}.0`]) {
+      key = key.replace(/\//g, '.')
+    }
 
     if (!this.activeMessages[key]) {
       const hasChildItems = this.activeMessages[`${key}.0`] !== undefined

--- a/test/fixtures/lang/en.json
+++ b/test/fixtures/lang/en.json
@@ -2,5 +2,7 @@
     "Welcome!": "Wecome!",
     "Welcome, :name!": "Welcome, :name!",
     "Only Available on EN": "Only Available on EN",
-    "{1} :count minute ago|[2,*] :count minutes ago": "{1} :count minute ago|[2,*] :count minutes ago"
+    "{1} :count minute ago|[2,*] :count minutes ago": "{1} :count minute ago|[2,*] :count minutes ago",
+    "Start/end": "Start/End",
+    "Get started.": "Get started."
 }

--- a/test/fixtures/lang/pt.json
+++ b/test/fixtures/lang/pt.json
@@ -2,5 +2,7 @@
     "Welcome!": "Bem-vindo!",
     "Welcome, :name!": "Bem-vindo, :name!",
     "{1} :count minute ago|[2,*] :count minutes ago": "{1} há :count minuto|[2,*] há :count minutos",
-    "foo.bar": "baz"
+    "foo.bar": "baz",
+    "Start/end": "Início/Fim",
+    "Get started.": "Comece."
 }

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -198,3 +198,10 @@ it('translates a nested file item while using "/" and "." at the same time as a 
   expect(trans('nested/cars/car.is_electric')).toBe('É elétrico?');
   expect(trans('nested/cars/car.foo.level1.level2')).toBe('barpt');
 })
+
+it('does not translate existing strings which contain delimiter symbols', async () => {
+  await global.mountPlugin()
+
+  expect(trans('Start/end')).toBe('Início/Fim');
+  expect(trans('Get started.')).toBe('Comece.');
+})


### PR DESCRIPTION
When using the `/` delimiter we should check whether the translation exists or not before replacing the string.