### PR TITLE
Fix fallback locale

### DIFF
--- a/src/interfaces/options.ts
+++ b/src/interfaces/options.ts
@@ -6,6 +6,7 @@ import { LanguageJsonFileInterface } from './language-json-file'
 export interface OptionsInterface {
   lang?: string
   fallbackLang?: string
+  fallbackMissingTranslations?: boolean
   resolve?(lang: string): Promise<LanguageJsonFileInterface>
   onLoad?: (lang: string) => void
 }

--- a/test/class.test.ts
+++ b/test/class.test.ts
@@ -84,3 +84,21 @@ it('calls onLoad when loaded', async () => {
     expect(onLoadFunction).toHaveBeenCalledWith('en')
     expect(onLoadFunction).toHaveBeenCalledWith('pt')
 })
+
+it('can override missing translations with fallback language translations', async () => {
+    const onLoadFunction = jest.fn()
+    const i18n = new I18n({
+        fallbackLang: 'en',
+        fallbackMissingTranslations: true,
+        resolve: lang => import(`./fixtures/lang/${lang}.json`),
+        onLoad: onLoadFunction
+    })
+    await i18n.loadLanguageAsync('pt')
+
+    expect(onLoadFunction).toHaveBeenCalledTimes(1)
+
+    expect(i18n.getActiveLanguage()).toBe('pt')
+    expect(i18n.trans('Welcome!')).toBe('Bem-vindo!')
+
+    expect(i18n.trans('English only.')).toBe('English only.')
+})

--- a/test/fixtures/lang/en.json
+++ b/test/fixtures/lang/en.json
@@ -4,5 +4,6 @@
     "Only Available on EN": "Only Available on EN",
     "{1} :count minute ago|[2,*] :count minutes ago": "{1} :count minute ago|[2,*] :count minutes ago",
     "Start/end": "Start/End",
-    "Get started.": "Get started."
+    "Get started.": "Get started.",
+    "English only.": "English only."
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -2,12 +2,13 @@ import { mount } from '@vue/test-utils'
 import { i18nVue } from '../src'
 import { parseAll } from '../src/loader'
 
-global.mountPlugin = async (template = '<div />', lang = 'pt', fallbackLang = 'pt') => {
+global.mountPlugin = async (template = '<div />', lang = 'pt', fallbackLang = 'pt', fallbackMissingTranslations = false) => {
   const wrapper = mount({ template }, {
     global: {
       plugins: [[i18nVue, {
         lang,
         fallbackLang,
+        fallbackMissingTranslations,
         resolve: lang => import(`./fixtures/lang/${lang}.json`),
       }]]
     }

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -47,6 +47,13 @@ it('fallback to the `fallbackLang` if the `lang` was not found', async () => {
   expect(trans('Welcome!')).toBe('Bem-vindo!');
 });
 
+it('fallback individual translation entries to the `fallbackLang` if translation was not found in the active language', async () => {
+  await global.mountPlugin(`<div />`, 'pt', 'en', 'true');
+
+  expect(trans('Welcome!')).toBe('Bem-vindo!');
+  expect(trans('English only.')).toBe('English only.');
+});
+
 it('returns the given key if the key is not available on the lang', async () => {
   await global.mountPlugin(`<div />`, 'en');
   expect(trans('Only Available on EN')).toBe('Only Available on EN');


### PR DESCRIPTION
Fix for [Issue 87: FallbackLocale not working](https://github.com/xiCO2k/laravel-vue-i18n/issues/87)

fallback locale is loaded first (in browser mode)
if active message has no value or the value equals with the key then use fallback locale translation