### PR TITLE
Vite plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,35 @@ export default defineConfig({
 });
 ```
 
+##### Vite plugin options
+
+In addition to that, you can use this `Vite` plugin with additional paths to load from, this is usefull when you are using a package that let's you override your translations, or in case you are getting your application's lang files from different paths. 
+
+```js
+// vite.config.js
+import i18n from 'laravel-vue-i18n/vite';
+
+export default defineConfig({
+    plugins: [
+        laravel([
+            'resources/css/app.css'
+            'resources/js/app.js',
+        ]),
+        vue(),
+
+        i18n({
+            // you can also change your langPath here
+            // langPath: 'locales' 
+            additionalLangPaths: [
+                'public/locales' // Load translations from this path too! 
+            ]
+        }),
+    ],
+});
+```
+
+Note that if one key found in two paths, priority will be given to the last given path between these two (In this example translation key will be loaded from `public/locales`)
+
 > During the `npm run dev` execution time, the plugin will create some files like this `php_{lang}.json` on your lang folder.
 > And to avoid that to be commited to your code base, I suggest to your `.gitignore` this like:
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ export default defineConfig({
 });
 ```
 
-##### Vite plugin options
+#### Vite plugin options
 
 In addition to that, you can use this `Vite` plugin with additional paths to load from, this is usefull when you are using a package that let's you override your translations, or in case you are getting your application's lang files from different paths. 
+
+Note that if one key found in two paths, priority will be given to the last given path between these two (In this example translation key will be loaded from `public/locales`)
 
 ```js
 // vite.config.js
@@ -112,8 +114,6 @@ export default defineConfig({
     ],
 });
 ```
-
-Note that if one key found in two paths, priority will be given to the last given path between these two (In this example translation key will be loaded from `public/locales`)
 
 > During the `npm run dev` execution time, the plugin will create some files like this `php_{lang}.json` on your lang folder.
 > And to avoid that to be commited to your code base, I suggest to your `.gitignore` this like:

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ createApp()
 
 #### SSR (Server Side Rendering)
 
-For Server Side Rendering the resolve method should not receive a `Promise` and instead take advantage of the `globEager` method like this:
+For Server Side Rendering the resolve method should not receive a `Promise` and instead take advantage of the `eager` param like this:
 
 ```js
 .use(i18nVue, {
     lang: 'pt',
     resolve: lang => {
-        const langs = import.meta.globEager('../../lang/*.json');
+        const langs = import.meta.glob('../../lang/*.json', { eager: true });
         return langs[`../../lang/${lang}.json`].default;
     },
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "laravel-vue-i18n",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "laravel-vue-i18n",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "php-parser": "3.1.3",

--- a/src/interfaces/plugin-options.ts
+++ b/src/interfaces/plugin-options.ts
@@ -8,5 +8,6 @@ export interface PluginOptionsInterface extends OptionsInterface {
 }
 
 export interface VitePluginOptionsInterface {
+  langPath?: string,
   additionalLangPaths?: string[]
 }

--- a/src/interfaces/plugin-options.ts
+++ b/src/interfaces/plugin-options.ts
@@ -6,3 +6,7 @@ import { OptionsInterface } from './options'
 export interface PluginOptionsInterface extends OptionsInterface {
   shared?: boolean
 }
+
+export interface VitePluginOptionsInterface {
+  additionalLangPaths?: string[]
+}

--- a/src/interfaces/plugin-options.ts
+++ b/src/interfaces/plugin-options.ts
@@ -8,6 +8,6 @@ export interface PluginOptionsInterface extends OptionsInterface {
 }
 
 export interface VitePluginOptionsInterface {
-  langPath?: string,
+  langPath?: string
   additionalLangPaths?: string[]
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -147,12 +147,8 @@ export const readThroughDir = (dir) => {
   return data
 }
 
-export const prepareExtendedParsedLangFiles = (langPaths: string[]) => 
-  langPaths.reduce(
-    (acc, langPath) => [...acc, ...parseAll(langPath)],
-    new Array<ParsedLangFileInterface>()
-  )
-
+export const prepareExtendedParsedLangFiles = (langPaths: string[]) =>
+  langPaths.reduce((acc, langPath) => [...acc, ...parseAll(langPath)], new Array<ParsedLangFileInterface>())
 
 export const generateFiles = (langPath: string, data: ParsedLangFileInterface[]): ParsedLangFileInterface[] => {
   data = mergeData(data)

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -147,6 +147,13 @@ export const readThroughDir = (dir) => {
   return data
 }
 
+export const prepareExtendedParsedLangFiles = (langPaths: string[]) => 
+  langPaths.reduce(
+    (acc, langPath) => [...acc, ...parseAll(langPath)],
+    new Array<ParsedLangFileInterface>()
+  )
+
+
 export const generateFiles = (langPath: string, data: ParsedLangFileInterface[]): ParsedLangFileInterface[] => {
   data = mergeData(data)
 

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -1,12 +1,15 @@
 import path from 'path'
-import { existsSync, writeFileSync, unlinkSync, readdirSync, rmdirSync } from 'fs'
-import { parseAll, hasPhpTranslations, generateFiles, prepareExtendedParsedLangFiles } from './loader'
+import { existsSync, unlinkSync, readdirSync, rmdirSync } from 'fs'
+import { hasPhpTranslations, generateFiles, prepareExtendedParsedLangFiles } from './loader'
 import { ParsedLangFileInterface } from './interfaces/parsed-lang-file'
 import { VitePluginOptionsInterface } from './interfaces/plugin-options'
 import { Plugin } from 'vite'
 
-export default function i18n(langPath: string = 'lang', options: VitePluginOptionsInterface = {}): Plugin {
+export default function i18n(options: string|VitePluginOptionsInterface = 'lang'): Plugin {
+  let langPath = typeof options === 'string' ? options : options.langPath ?? 'lang'
   langPath = langPath.replace(/[\\/]$/, '') + path.sep
+
+  const additionalLangPaths = typeof options === 'string' ? [] : options.additionalLangPaths ?? []
 
   const frameworkLangPath = 'vendor/laravel/framework/src/Illuminate/Translation/lang/'.replace('/', path.sep)
   let files: ParsedLangFileInterface[] = []
@@ -41,23 +44,23 @@ export default function i18n(langPath: string = 'lang', options: VitePluginOptio
         return
       }
 
-      const additionalLangPaths = prepareExtendedParsedLangFiles([
+      const langPaths = prepareExtendedParsedLangFiles([
         frameworkLangPath,
         langPath,
-        ...(options.additionalLangPaths ?? []),
+        ...additionalLangPaths,
       ])
 
-      files = generateFiles(langPath, additionalLangPaths)
+      files = generateFiles(langPath, langPaths)
     },
     handleHotUpdate(ctx) {
       if (/lang\/.*\.php$/.test(ctx.file)) {
-        const additionalLangPaths = prepareExtendedParsedLangFiles([
+        const langPaths = prepareExtendedParsedLangFiles([
           frameworkLangPath,
           langPath,
-          ...(options.additionalLangPaths ?? []),
+          ...additionalLangPaths,
         ])
 
-        files = generateFiles(langPath, additionalLangPaths)
+        files = generateFiles(langPath, langPaths)
       }
     },
     configureServer(server) {

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -5,7 +5,7 @@ import { ParsedLangFileInterface } from './interfaces/parsed-lang-file'
 import { VitePluginOptionsInterface } from './interfaces/plugin-options'
 import { Plugin } from 'vite'
 
-export default function i18n(options: string|VitePluginOptionsInterface = 'lang'): Plugin {
+export default function i18n(options: string | VitePluginOptionsInterface = 'lang'): Plugin {
   let langPath = typeof options === 'string' ? options : options.langPath ?? 'lang'
   langPath = langPath.replace(/[\\/]$/, '') + path.sep
 
@@ -44,21 +44,13 @@ export default function i18n(options: string|VitePluginOptionsInterface = 'lang'
         return
       }
 
-      const langPaths = prepareExtendedParsedLangFiles([
-        frameworkLangPath,
-        langPath,
-        ...additionalLangPaths,
-      ])
+      const langPaths = prepareExtendedParsedLangFiles([frameworkLangPath, langPath, ...additionalLangPaths])
 
       files = generateFiles(langPath, langPaths)
     },
     handleHotUpdate(ctx) {
       if (/lang\/.*\.php$/.test(ctx.file)) {
-        const langPaths = prepareExtendedParsedLangFiles([
-          frameworkLangPath,
-          langPath,
-          ...additionalLangPaths,
-        ])
+        const langPaths = prepareExtendedParsedLangFiles([frameworkLangPath, langPath, ...additionalLangPaths])
 
         files = generateFiles(langPath, langPaths)
       }

--- a/test/fixtures/locales/en/auth.php
+++ b/test/fixtures/locales/en/auth.php
@@ -1,0 +1,6 @@
+<?php 
+
+return [
+    'failed' => 'These credentials are incorrect.',
+    'throttle' => 'Too many login attempts. Please try again in :seconds seconds.'
+];

--- a/test/fixtures/locales/en/domain/user.php
+++ b/test/fixtures/locales/en/domain/user.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'sub_dir_support_is_amazing' => 'Subdirectory override is amazing',
+];

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -59,7 +59,7 @@ it('inclues additional lang paths to load from', () => {
     expect(langEn['auth.throttle']).toBe('Too many login attempts. Please try again in :seconds seconds.');
 });
 
-it('Overwrites translations from additional lang paths', () => {
+it('overwrites translations from additional lang paths', () => {
     const langPath = __dirname + '/fixtures/lang/';
     const additionalLangPaths = [
         __dirname + '/fixtures/locales/'

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { generateFiles, parseAll, parse, hasPhpTranslations, reset } from '../src/loader';
+import { generateFiles, parseAll, parse, hasPhpTranslations, reset, prepareExtendedParsedLangFiles } from '../src/loader';
 
 beforeEach(() => reset(__dirname + '/fixtures/lang/'));
 
@@ -40,6 +40,43 @@ it('includes .php lang file in nested subdirectory in .json', () => {
     expect(langEn['nested.cars.car.is_electric']).toBe('Electric');
     expect(langEn['nested.cars.car.foo.level1.level2']).toBe('barpt');
 })
+
+it('inclues additional lang paths to load from', () => {
+    const langPath = __dirname + '/fixtures/lang/';
+    const additionalLangPaths = [
+        __dirname + '/fixtures/locales/'
+    ];
+
+    const langPaths = prepareExtendedParsedLangFiles([
+        langPath,
+        ...additionalLangPaths,
+    ]);
+
+    const files = generateFiles(langPath, langPaths);
+
+    const langEn = JSON.parse(fs.readFileSync(langPath + files[0].name).toString());
+
+    expect(langEn['auth.throttle']).toBe('Too many login attempts. Please try again in :seconds seconds.');
+});
+
+it('Overwrites translations from additional lang paths', () => {
+    const langPath = __dirname + '/fixtures/lang/';
+    const additionalLangPaths = [
+        __dirname + '/fixtures/locales/'
+    ];
+
+    const langPaths = prepareExtendedParsedLangFiles([
+        langPath,
+        ...additionalLangPaths,
+    ]);
+
+    const files = generateFiles(langPath, langPaths);
+
+    const langEn = JSON.parse(fs.readFileSync(langPath + files[0].name).toString());
+
+    expect(langEn['auth.failed']).toBe('These credentials are incorrect.');
+    expect(langEn['domain.user.sub_dir_support_is_amazing']).toBe('Subdirectory override is amazing');
+});
 
 it('transforms .php lang to .json', () => {
     const lang = parse(fs.readFileSync(__dirname + '/fixtures/lang/en/auth.php').toString());


### PR DESCRIPTION
With this PR, we can now pass additional paths from where we will load our translations, this is usefull when we are splitting our application's translations into different folders/paths, and/or we are using a package that helps us override default translations.