### PR TITLE
fix: Ignore `null` and empty `array` `php` translations

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -77,6 +77,10 @@ const parseItem = (expr) => {
     return expr.value
   }
 
+  if (expr.kind === 'nullkeyword') {
+    return null;
+  }
+
   if (expr.kind === 'array') {
     let items = expr.items.map((item) => parseItem(item))
 
@@ -101,6 +105,10 @@ const parseItem = (expr) => {
 const convertToDotsSyntax = (list) => {
   const flatten = (items, context = '') => {
     const data = {}
+
+    if (items === null) {
+      return data;
+    }
 
     Object.entries(items).forEach(([key, value]) => {
       if (typeof value === 'string') {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -78,7 +78,7 @@ const parseItem = (expr) => {
   }
 
   if (expr.kind === 'nullkeyword') {
-    return null;
+    return null
   }
 
   if (expr.kind === 'array') {
@@ -107,7 +107,7 @@ const convertToDotsSyntax = (list) => {
     const data = {}
 
     if (items === null) {
-      return data;
+      return data
     }
 
     Object.entries(items).forEach(([key, value]) => {

--- a/test/fixtures/lang/en/ignore.php
+++ b/test/fixtures/lang/en/ignore.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'empty_array' => [],
+    'null' => null,
+];

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -98,6 +98,13 @@ it('transforms simple index array to .json', () => {
     expect(lang['arr.1']).toBe('bar');
 });
 
+it('ignores empty `array` or `null` translations', () => {
+    const lang = parse(fs.readFileSync(__dirname + '/fixtures/lang/en/ignore.php').toString());
+
+    expect(lang['empty_array']).toBe(undefined);
+    expect(lang['null']).toBe(undefined);
+});
+
 it('checks if there is .php translations', () => {
     expect(hasPhpTranslations(__dirname + '/fixtures/lang/')).toBe(true);
     expect(hasPhpTranslations(__dirname + '/fixtures/wronglangfolder/')).toBe(false);


### PR DESCRIPTION
Fixes #158