### PR TITLE
fix: check file existence before unlinking (vite.buildEnd --> clear)

### DIFF
--- a/src/vite.ts
+++ b/src/vite.ts
@@ -16,7 +16,12 @@ export default function i18n(options: string | VitePluginOptionsInterface = 'lan
   let exitHandlersBound: boolean = false
 
   const clean = () => {
-    files.forEach((file) => unlinkSync(langPath + file.name))
+    files.forEach((file) => {
+      const filePath = langPath + file.name
+      if (existsSync(filePath)) {
+        unlinkSync(filePath)
+      }
+    })
 
     files = []
 


### PR DESCRIPTION
### Problem

For a while now, I haven't understood why the Vite dev script stopped with an error message indicating an attempt to delete an already deleted language file when called buildEnd function.

```
node:fs:1876
  binding.unlink(path);
          ^

Error: ENOENT: no such file or directory, unlink 'lang/php_en.json'
    at unlinkSync (node:fs:1876:11)
    at file:///github/secret/node_modules/.pnpm/laravel-vue-i18n@2.7.6_typescript@5.3.3/node_modules/laravel-vue-i18n/dist/vite.mjs:12:33
    at Array.forEach (<anonymous>)
    at process.clean (file:///github/secret/node_modules/.pnpm/laravel-vue-i18n@2.7.6_typescript@5.3.3/node_modules/laravel-vue-i18n/dist/vite.mjs:12:15)
    at process.emit (node:events:531:35)
    at process.exit (node:internal/process/per_thread:192:15)
    at process.<anonymous> (file:///github/secret/node_modules/.pnpm/laravel-vite-plugin@1.0.1_vite@5.1.3/node_modules/laravel-vite-plugin/dist/index.js:127:44)
    at process.emit (node:events:531:35) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'unlink',
  path: 'lang/php_en.json'
}

Node.js v21.5.0
```

### Solution

I see the original idea, and it would be logical that during the clean() function execution, theoretically, every file exists.

However, if not, I'll always encounter an error. I've made a PR to fixed this.

