### PR TITLE
feat: avoid displaying the key until loading

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -413,7 +413,7 @@ export class I18n {
         value = this.findTranslation(key.replace(/\//g, '.'))
       }
 
-      this.activeMessages[key] = this.isValid(value) ? value : key
+      this.activeMessages[key] = this.isValid(value) ? value : (this.isLoaded() ? key : '')
     })
 
     return computed(() => this.makeReplacements(this.activeMessages[key], replacements))

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -16,7 +16,12 @@ export default function i18n(options: string | VitePluginOptionsInterface = 'lan
   let exitHandlersBound: boolean = false
 
   const clean = () => {
-    files.forEach((file) => unlinkSync(langPath + file.name))
+    files.forEach((file) => {
+      const filePath = langPath + file.name
+      if (existsSync(filePath)) {
+        unlinkSync(filePath)
+      }
+    })
 
     files = []
 


### PR DESCRIPTION
If the page is not loaded based on SSR, then when the language file loading takes even slightly longer than the rest of the frontend, the key briefly appears for a very short time. This creates a sensation of "vibration". It would be much better if the wTrans (and other dependent functions) function returned nothing until the loading is complete.

I've made a video (not the most professional, but it illustrates the difference), playing back the loading process at 0.1x speed.

https://github.com/xiCO2k/laravel-vue-i18n/assets/67325669/cab5a542-2e26-4707-a1c7-429d1ff533f6

