### PR TITLE
Support for published package language vendor files

### DIFF
--- a/test/fixtures/lang/vendor/package-example/en/messages.php
+++ b/test/fixtures/lang/vendor/package-example/en/messages.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'welcome' => 'Welcome to the example package.',
+    'success' => 'The package did the task successfully.',
+    'foo' => [
+        'level1' => [
+            'level2' => 'package'
+        ]
+    ],
+    'arr' => ['foo', 'bar'],
+    'multiline' => 'Lorem ' .
+        'ipsum ' .
+        'dolor ' .
+        'sit ' .
+        'amet.',
+];

--- a/test/fixtures/lang/vendor/package-example/pt/messages.php
+++ b/test/fixtures/lang/vendor/package-example/pt/messages.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'welcome' => 'Bem-vindo ao exemplo do pacote.',
+    'success' => 'O pacote executou a tarefa com sucesso.',
+    'foo' => [
+        'level1' => [
+            'level2' => 'pacote'
+        ]
+    ],
+    'arr' => ['foo', 'bar'],
+    'multiline' => 'Lorem ' .
+        'ipsum ' .
+        'dolor ' .
+        'sit ' .
+        'amet.',
+];

--- a/test/folderIsolationUtil.ts
+++ b/test/folderIsolationUtil.ts
@@ -1,0 +1,27 @@
+import fs from 'fs'
+import path from 'path'
+
+export function isolateFolder(folderToIsolate: string, testName: string) {
+    const isolatedFolder = folderToIsolate + '_isolated_' + testName;
+    copyDirSync(folderToIsolate, isolatedFolder);
+
+    return isolatedFolder;
+}
+
+export function removeIsolatedFolder(isolatedFolder: string) {
+    fs.rmSync(isolatedFolder, { recursive: true, force: true })
+}
+
+function copyDirSync(source: string, destination: string) {
+    const exists = fs.existsSync(source);
+    const stats = exists && fs.statSync(source);
+    const isDirectory = exists && stats.isDirectory();
+    if (isDirectory) {
+        fs.mkdirSync(destination);
+        fs.readdirSync(source).forEach(childItemName => {
+            copyDirSync(path.join(source, childItemName), path.join(destination, childItemName));
+        });
+    } else {
+        fs.copyFileSync(source, destination);
+    }
+}

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -1,10 +1,14 @@
 import fs from 'fs';
 import { generateFiles, parseAll, parse, hasPhpTranslations, reset, prepareExtendedParsedLangFiles } from '../src/loader';
+import { isolateFolder, removeIsolatedFolder } from './folderIsolationUtil'
 
-beforeEach(() => reset(__dirname + '/fixtures/lang/'));
+const isolatedFixtures = isolateFolder(__dirname + '/fixtures', 'loader');
+afterAll(() => removeIsolatedFolder(isolatedFixtures));
+
+beforeEach(() => reset(isolatedFixtures + '/lang/'));
 
 it('creates a file for each lang', () => {
-    const langPath = __dirname + '/fixtures/lang/';
+    const langPath = isolatedFixtures + '/lang/';
     const files = generateFiles(langPath, parseAll(langPath));
 
     expect(files.length).toBe(3);
@@ -23,7 +27,7 @@ it('creates a file for each lang', () => {
 });
 
 it('merges published package translations into each lang .json', () => {
-    const langPath = __dirname + '/fixtures/lang/';
+    const langPath = isolatedFixtures + '/lang/';
     const files = generateFiles(langPath, parseAll(langPath));
 
     expect(files.length).toBe(3);
@@ -47,7 +51,7 @@ it('merges published package translations into each lang .json', () => {
 });
 
 it('includes .php lang file in subdirectory in .json', () => {
-    const langPath = __dirname + '/fixtures/lang/';
+    const langPath = isolatedFixtures + '/lang/';
     const files = generateFiles(langPath, parseAll(langPath));
     const langEn = JSON.parse(fs.readFileSync(langPath + files[0].name).toString());
 
@@ -57,7 +61,7 @@ it('includes .php lang file in subdirectory in .json', () => {
 });
 
 it('includes .php lang file in nested subdirectory in .json', () => {
-    const langPath = __dirname + '/fixtures/lang/';
+    const langPath = isolatedFixtures + '/lang/';
     const files = generateFiles(langPath, parseAll(langPath));
     const langEn = JSON.parse(fs.readFileSync(langPath + files[0].name).toString())
 
@@ -66,9 +70,9 @@ it('includes .php lang file in nested subdirectory in .json', () => {
 })
 
 it('inclues additional lang paths to load from', () => {
-    const langPath = __dirname + '/fixtures/lang/';
+    const langPath = isolatedFixtures + '/lang/';
     const additionalLangPaths = [
-        __dirname + '/fixtures/locales/'
+        isolatedFixtures + '/locales/'
     ];
 
     const langPaths = prepareExtendedParsedLangFiles([
@@ -84,9 +88,9 @@ it('inclues additional lang paths to load from', () => {
 });
 
 it('overwrites translations from additional lang paths', () => {
-    const langPath = __dirname + '/fixtures/lang/';
+    const langPath = isolatedFixtures + '/lang/';
     const additionalLangPaths = [
-        __dirname + '/fixtures/locales/'
+        isolatedFixtures + '/locales/'
     ];
 
     const langPaths = prepareExtendedParsedLangFiles([
@@ -103,33 +107,33 @@ it('overwrites translations from additional lang paths', () => {
 });
 
 it('transforms .php lang to .json', () => {
-    const lang = parse(fs.readFileSync(__dirname + '/fixtures/lang/en/auth.php').toString());
+    const lang = parse(fs.readFileSync(isolatedFixtures + '/lang/en/auth.php').toString());
 
     expect(lang['failed']).toBe('These credentials do not match our records.');
 });
 
 it('transform nested .php lang files to .json', () => {
-    const langPt = parse(fs.readFileSync(__dirname + '/fixtures/lang/pt/auth.php').toString());
+    const langPt = parse(fs.readFileSync(isolatedFixtures + '/lang/pt/auth.php').toString());
     expect(langPt['foo.level1.level2']).toBe('barpt');
 
-    const langEn = parse(fs.readFileSync(__dirname + '/fixtures/lang/en/auth.php').toString());
+    const langEn = parse(fs.readFileSync(isolatedFixtures + '/lang/en/auth.php').toString());
     expect(langEn['foo.level1.level2']).toBe('baren');
 });
 
 it('transforms simple index array to .json', () => {
-    const lang = parse(fs.readFileSync(__dirname + '/fixtures/lang/en/auth.php').toString());
+    const lang = parse(fs.readFileSync(isolatedFixtures + '/lang/en/auth.php').toString());
     expect(lang['arr.0']).toBe('foo');
     expect(lang['arr.1']).toBe('bar');
 });
 
 it('ignores empty `array` or `null` translations', () => {
-    const lang = parse(fs.readFileSync(__dirname + '/fixtures/lang/en/ignore.php').toString());
+    const lang = parse(fs.readFileSync(isolatedFixtures + '/lang/en/ignore.php').toString());
 
     expect(lang['empty_array']).toBe(undefined);
     expect(lang['null']).toBe(undefined);
 });
 
 it('checks if there is .php translations', () => {
-    expect(hasPhpTranslations(__dirname + '/fixtures/lang/')).toBe(true);
-    expect(hasPhpTranslations(__dirname + '/fixtures/wronglangfolder/')).toBe(false);
+    expect(hasPhpTranslations(isolatedFixtures + '/lang/')).toBe(true);
+    expect(hasPhpTranslations(isolatedFixtures + '/wronglangfolder/')).toBe(false);
 });

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -7,11 +7,10 @@ it('creates a file for each lang', () => {
     const langPath = __dirname + '/fixtures/lang/';
     const files = generateFiles(langPath, parseAll(langPath));
 
-    expect(files.length).toBe(4);
+    expect(files.length).toBe(3);
     expect(files[0].name).toBe('php_en.json');
     expect(files[1].name).toBe('php_fr.json');
     expect(files[2].name).toBe('php_pt.json');
-    expect(files[3].name).toBe('php_vendor.json');
 
     const langEn = JSON.parse(fs.readFileSync(langPath + files[0].name).toString());
     expect(langEn['auth.failed']).toBe('These credentials do not match our records.');
@@ -25,7 +24,7 @@ it('creates a file for each lang', () => {
 
 it('merges published package translations into each lang .json', () => {
     const langPath = __dirname + '/fixtures/lang/';
-    const files = generateFiles(langPath, prepareExtendedParsedLangFiles([langPath]));
+    const files = generateFiles(langPath, parseAll(langPath));
 
     expect(files.length).toBe(3);
     expect(files[0].name).toBe('php_en.json');

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -7,10 +7,11 @@ it('creates a file for each lang', () => {
     const langPath = __dirname + '/fixtures/lang/';
     const files = generateFiles(langPath, parseAll(langPath));
 
-    expect(files.length).toBe(3);
+    expect(files.length).toBe(4);
     expect(files[0].name).toBe('php_en.json');
     expect(files[1].name).toBe('php_fr.json');
     expect(files[2].name).toBe('php_pt.json');
+    expect(files[3].name).toBe('php_vendor.json');
 
     const langEn = JSON.parse(fs.readFileSync(langPath + files[0].name).toString());
     expect(langEn['auth.failed']).toBe('These credentials do not match our records.');
@@ -20,6 +21,30 @@ it('creates a file for each lang', () => {
     const langPt = JSON.parse(fs.readFileSync(langPath + files[2].name).toString());
     expect(langPt['auth.failed']).toBe('As credenciais indicadas não coincidem com as registadas no sistema.');
     expect(langPt['auth.foo.level1.level2']).toBe('barpt');
+});
+
+it('merges published package translations into each lang .json', () => {
+    const langPath = __dirname + '/fixtures/lang/';
+    const files = generateFiles(langPath, prepareExtendedParsedLangFiles([langPath]));
+
+    expect(files.length).toBe(3);
+    expect(files[0].name).toBe('php_en.json');
+    expect(files[1].name).toBe('php_fr.json');
+    expect(files[2].name).toBe('php_pt.json');
+
+    const langEn = JSON.parse(fs.readFileSync(langPath + files[0].name).toString());
+    expect(langEn['package-example::messages.welcome']).toBe('Welcome to the example package.');
+    expect(langEn['package-example::messages.foo.level1.level2']).toBe('package');
+    expect(langEn['package-example::messages.multiline']).toBe('Lorem ipsum dolor sit amet.');
+
+    const langFr = JSON.parse(fs.readFileSync(langPath + files[1].name).toString());
+    expect(langFr['package-example::messages.welcome']).toBeUndefined();
+    expect(langFr['package-example::messages.foo.level1.level2']).toBeUndefined();
+    expect(langFr['package-example::messages.multiline']).toBeUndefined();
+
+    const langPt = JSON.parse(fs.readFileSync(langPath + files[2].name).toString());
+    expect(langPt['package-example::messages.welcome']).toBe('Bem-vindo ao exemplo do pacote.');
+    expect(langPt['package-example::messages.foo.level1.level2']).toBe('pacote');
 });
 
 it('includes .php lang file in subdirectory in .json', () => {


### PR DESCRIPTION
This update addresses an issue where a 'php_vendor.json' file is generated but not utilized, as it is not imported by the plugin resolver.

**Changes**

- Removed the generation of the 'php_vendor.json' file from the published package language files.
- Merged the content of 'php_vendor.json' directly into the actual language files used by the resolver.