### PR TITLE
Augment `vue` instead of `@vue/runtime-core`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ export const trans_choice = transChoice
 /**
  * Type declarations for `$t` and `$tChoice` mixins.
  */
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $t: typeof trans
     $tChoice: typeof transChoice


### PR DESCRIPTION
Hi, @xiCO2k, thanks for developing a great package!

As already pulled in other packages, e.g. https://github.com/primefaces/primevue/issues/6199, https://github.com/inertiajs/inertia/pull/2099, it seems that the augmentations with custom properties should use the `'vue'` module instead of `'@vue/runtime-core'`. Also, it is documented [on the Vue.js page](https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties).

For me it caused an issue with my Inertia app dev experience, where my `$page` property had lost its type in Vue SFC template. It seems it has been resolved with this commit (at least for me).

Cheers!