### PR TITLE
fix: add undefined check for expr in parseItem function

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -110,6 +110,8 @@ export const parse = (content: string) => {
 }
 
 const parseItem = (expr) => {
+  if(!expr) return;
+
   if (expr.kind === 'string') {
     return expr.value
   }
@@ -155,7 +157,7 @@ const convertToDotsSyntax = (list) => {
   const flatten = (items, context = '') => {
     const data = {}
 
-    if (items === null) {
+    if (items === null || items === undefined) {
       return data
     }
 

--- a/test/fixtures/lang/en/ignore.php
+++ b/test/fixtures/lang/en/ignore.php
@@ -3,4 +3,5 @@
 return [
     'empty_array' => [],
     'null' => null,
+    'undefined' => undefined,
 ];

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -141,11 +141,12 @@ it('transforms class names and consts to .json', () => {
     expect(lang['name']).toBe('Name');
 });
 
-it('ignores empty `array` or `null` translations', () => {
+it('ignores empty `array`, `null`, or `undefined` translations', () => {
     const lang = parse(fs.readFileSync(isolatedFixtures + '/lang/en/ignore.php').toString());
 
     expect(lang['empty_array']).toBe(undefined);
     expect(lang['null']).toBe(undefined);
+    expect(lang['undefined']).toBe(undefined);
 });
 
 it('checks if there is .php translations', () => {


### PR DESCRIPTION
> This isn't a "bug" with the code but rather uncovered by bad / unsupported functionality when using laravels `__` function in unintended ways 

- Prevents errors when expr is null or undefined allowing build to succeed. 
- Follow same path as if expr is `null`

![image](https://github.com/user-attachments/assets/e328f205-e755-466f-96db-96a6cbab544f)
